### PR TITLE
Remove origami-component config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,28 +1,36 @@
 module.exports = {
-    "extends": [
-        "airbnb-base",
-        "origami-component"
+    'extends': [
+        'airbnb-base'
     ],
-    "plugins": [],
-    "parserOptions": {
-        sourceType: "script"
+    'plugins': [],
+    'parserOptions': {
+        ecmaVersion: 2017,
+        sourceType: 'script',
+        impliedStrict: false,
+        ecmaFeatures: {
+            experimentalObjectRestSpread: false,
+        },
     },
-    "rules": {
-        'arrow-body-style': 0,
-        'arrow-parens': [2, "always"],
-        'func-names': 0,
-        'import/no-extraneous-dependencies': [2, {'devDependencies': ['test/**/*.js', '**/*.test.js', '**/*.spec.js', 'gulpfile.js', 'gulp-tasks/**/*.js']}],
-        'import/no-named-as-default': 0, // doesn't work with decorated defaults https://github.com/benmosher/eslint-plugin-import/issues/544
-        'import/prefer-default-export': 0,
-        'indent': [2, 4],
-        'max-len': 1,
-        'new-cap':  [2, {capIsNewExceptions: ['Router']}],
-        'no-param-reassign': 0,
-        'no-underscore-dangle': [2, {allowAfterThis: true}],
-        'object-curly-spacing': [2, 'never'],
-        'padded-blocks': 0,
-        'prefer-arrow-callback': [2, {allowNamedFunctions: true}],
-        'quote-props': [2, 'as-needed', {numbers: true}],
-        'space-before-function-paren': [2, 'never']
+    'rules': {
+        'arrow-body-style': 'off',
+        'func-names': 'off',
+        'import/no-extraneous-dependencies': ['error', {
+            'devDependencies': [
+                'test/**/*.js', '**/*.test.js', '**/*.spec.js', 'gulpfile.js', 'gulp-tasks/**/*.js'
+            ]
+        }],
+        'import/no-named-as-default': 'off', // doesn't work with decorated defaults https://github.com/benmosher/eslint-plugin-import/issues/544
+        'import/prefer-default-export': 'off',
+        'indent': ['error', 4],
+        'max-len': 'warn',
+        'new-cap':  ['error', {capIsNewExceptions: ['Router']}],
+        'no-param-reassign': 'off',
+        'no-underscore-dangle': ['error', {allowAfterThis: true}],
+        'object-curly-spacing': ['error', 'never'],
+        'padded-blocks': 'off',
+        'prefer-arrow-callback': ['error', {allowNamedFunctions: true}],
+        'quote-props': ['error', 'as-needed', {numbers: true}],
+        'space-before-function-paren': ['error', 'never'],
+        'valid-jsdoc': 'off',
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/eslint-config-de-tooling",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -40,9 +40,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
       "dev": true
     },
     "ansi-escapes": {
@@ -285,9 +285,9 @@
       }
     },
     "debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
-      "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -340,9 +340,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.2.tgz",
-      "integrity": "sha1-/29fUZOEiifum2J74+c/ucteZi4=",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.8.0.tgz",
+      "integrity": "sha1-Ip7w41Tg5h2DfHqA/fuoJeGZgV4=",
       "dev": true,
       "requires": {
         "ajv": "5.2.3",
@@ -350,7 +350,7 @@
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "3.0.1",
+        "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
         "espree": "3.5.1",
@@ -380,22 +380,17 @@
         "semver": "5.4.1",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "4.0.1",
+        "table": "4.0.2",
         "text-table": "0.2.0"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.0.0.tgz",
-      "integrity": "sha512-/XlFQGn3Mkwm642/GYBtOH3pgFX4Z7saBsqqyp96v0bEUPq24nIrZ6N72qAoD0lR2wAne4EC4YsHYkbPfaRfiA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.0.1.tgz",
+      "integrity": "sha512-j9mEf21o09cO+wg4M9cwhvu88E5OxbhC94TjcDsSXfHD25LVmhB6gjy2jUv3JH642TshKKl/HBYzVFCjMd390Q==",
       "requires": {
         "eslint-restricted-globals": "0.1.1"
       }
-    },
-    "eslint-config-origami-component": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-origami-component/-/eslint-config-origami-component-1.0.0.tgz",
-      "integrity": "sha1-xqHXWLIns51QZ5b41ENFZTpwXkY="
     },
     "eslint-import-resolver-node": {
       "version": "0.3.1",
@@ -587,7 +582,7 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
     },
@@ -602,9 +597,9 @@
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
         "circular-json": "0.3.3",
@@ -1339,10 +1334,13 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -1432,51 +1430,17 @@
       "dev": true
     },
     "table": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
-      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
+        "ajv": "5.2.3",
+        "ajv-keywords": "2.1.0",
+        "chalk": "2.1.0",
         "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
+        "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -11,16 +11,15 @@
   "author": "charlie.briggs@ft.com",
   "license": "MIT",
   "dependencies": {
-    "eslint-config-airbnb-base": "^12.0.0",
-    "eslint-config-origami-component": "^1.0.0"
+    "eslint-config-airbnb-base": "^12.0.1"
   },
   "peerDependencies": {
-    "eslint": "^4.6.0",
+    "eslint": "^4.8.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-mocha": "^4.11.0"
   },
   "devDependencies": {
-    "eslint": "^4.6.0",
+    "eslint": "^4.8.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-mocha": "^4.11.0",
     "husky": "^0.14.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/eslint-config-de-tooling",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "eslint config for de-tooling projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This config is pretty outdated and throws warns whenever it's loaded, this is also the only visible FT project using it.

I considered switching to either:
* n-gage's scripts:
https://github.com/Financial-Times/n-gage/blob/ad7163b647991994b1f795bb06f033980a7aab63/dotfiles/.eslintrc.js
* origami-built-tools-scripts:
https://github.com/Financial-Times/origami-build-tools/blob/e492af7e2a4a1f707f3cf0384ed7c9e3d5931d49/config/.eslintrc

However these are also sufficiently inconsistent that it seemed easier to ignore them for now.