### PR TITLE
Change valid-jsdoc to warn

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,6 @@ module.exports = {
         'prefer-arrow-callback': ['error', {allowNamedFunctions: true}],
         'quote-props': ['error', 'as-needed', {numbers: true}],
         'space-before-function-paren': ['error', 'never'],
-        'valid-jsdoc': 'off',
+        'valid-jsdoc': 'warn',
     }
 }


### PR DESCRIPTION
This isn't enabled in airbnbs config but one of our projects ([cmdb.js](https://github.com/Financial-Times/cmdb.js)) uses jsdoc, so we should check them if using them, but not necessarily enforce them.