### PR TITLE
Loosen import/no-extraneous-dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,34 @@ module.exports = {
             experimentalObjectRestSpread: false,
         },
     },
+    'settings': {
+        'import/core-modules': [
+            'aws-sdk',
+        ],
+    },
     'rules': {
         'arrow-body-style': 'off',
         'func-names': 'off',
         'import/no-extraneous-dependencies': ['error', {
             'devDependencies': [
-                'test/**/*.js', '**/*.test.js', '**/*.spec.js', 'gulpfile.js', 'gulp-tasks/**/*.js'
+                'public', // public static asset paths
+                'test/**', // tape, common npm pattern
+                'tests/**', // also common npm pattern
+                'spec/**', // mocha, rspec-like pattern
+                '**/__tests__/**', // jest pattern
+                'test.{js,jsx}', // repos with a single test file
+                'test-*.{js,jsx}', // repos with multiple top-level test files
+                '**/*.{test,spec}.{js,jsx}', // tests where the extension denotes that it is a test
+                '**/jest.config.js', // jest config
+                '**/webpack.config.js', // webpack config
+                '**/webpack.config.*.js', // webpack config
+                '**/rollup.config.js', // rollup config
+                '**/rollup.config.*.js', // rollup config
+                '**/gulpfile.js', // gulp config
+                '**/gulpfile.*.js', // gulp config
+                '**/Gruntfile{,.js}', // grunt config
+                '**/protractor.conf.js', // protractor config
+                '**/protractor.conf.*.js', // protractor config
             ]
         }],
         'import/no-named-as-default': 'off', // doesn't work with decorated defaults https://github.com/benmosher/eslint-plugin-import/issues/544


### PR DESCRIPTION
This now treats public + webpack/rollup/jest/gulp config as dev dependencies

Also add aws-sdk as a core module as it's bundled on lambda