### PR TITLE
Disable 'global-require' when working with jest

### DIFF
--- a/rules/jest.js
+++ b/rules/jest.js
@@ -25,4 +25,8 @@ jestConfig.rules['jest/no-disabled-tests'] = [
 	{ extensions: ['.js', '.jsx'] },
 ];
 
+// Disable as it's frequently necessary to do inline requires
+// when working with jest mocks
+jestConfig.rules['global-require'] = 'off';
+
 module.exports = jestConfig;


### PR DESCRIPTION
This is common in jest tests when overriding mocks, particularly for modules instantiated at module-load time.

See https://eslint.org/docs/rules/global-require for rule reference.