### PR TITLE
allow describe blocks to use variables in the name

### DIFF
--- a/rules/jest.js
+++ b/rules/jest.js
@@ -5,10 +5,14 @@ const { usingJsx } = require('../lib/feature-detect');
 const config = {
 	extends: ['plugin:jest/recommended'],
 	rules: {
-		// This disallows .skip, which is auseful tool for writing skelton tests
+		// This disallows .skip, which is a useful tool for writing skelton tests
 		// prior to full implementation. no-focused-tests is still enabled, which
 		// catches .only - that's the killer
 		'jest/no-disabled-tests': [0, { extensions: ['.js', '.jsx'] }],
+		// This rule disallows using template strings with variables as description 
+		// names, which is useful when e.g. running the same set of tests with multiple
+		// configurations
+		'jest/valid-describe': 'off'
 
 		// Disable as it's frequently necessary to do inline requires
 		// when working with jest mocks


### PR DESCRIPTION
# Why
This linting rule errors on e.g. 
```
arrayOfConfigs.forEach(config => {
    describe(`error handling for ${config.type}`, () => { ... })
})
```

# What
disables the offending rule